### PR TITLE
Added "Text Domain: bpfb" in file header

### DIFF
--- a/bpfb.php
+++ b/bpfb.php
@@ -2,6 +2,7 @@
 /*
 Plugin Name: BuddyPress Activity Plus
 Plugin URI: http://premium.wpmudev.org/project/media-embeds-for-buddypress-activity
+Text Domain: bpfb
 Description: A Facebook-style media sharing improvement for the activity box.
 Version: 1.6
 Author: WPMU DEV


### PR DESCRIPTION
Without it translation isn't possible. 
More: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains